### PR TITLE
Fix keymap display

### DIFF
--- a/src/chrysalis/plugin/page/keymap/layout.cljs
+++ b/src/chrysalis/plugin/page/keymap/layout.cljs
@@ -71,32 +71,23 @@
 
     (if (and r c)
       (let [[cols rows] (get-in device [:meta :matrix])
-            index (key-index device r c cols)]
-
-        (condp = label
-          "primary"  (assoc node 2 (:primary-text (key/format(((events/layout) (events/layer)) index))))
-          "secondary" (assoc node 2 (:secondary-text (key/format(((events/layout) (events/layer)) index))))
-          "extra" (assoc node 2 (:extra-text (key/format(((events/layout) (events/layer)) index)))))
-        )
-      node))
-  )
-
-
+            index (key-index device r c cols)
+            ;; Note layers are 1-indexed, so we need `dec` to go to
+            ;; zero-indexed clojure vectors
+            formatted-key (key/format (get-in (events/layout) [(dec (events/layer)) index]))]
+        (assoc node 2 (get formatted-key (keyword (str label "-text")))))
+      node)))
 
 (defn prepare [device svg layout props]
   (walk/prewalk (fn [node]
-
                   (if (and (vector? node) (= (first node) :text))
                     (print-labels device node)
                     (if (and (map? node) (get node :id))
                       (node-update device node layout (:interactive? props))
-                      node))
-                  )
+                      node)))
 
                 (-> svg
                     (assoc 1 (assoc (dissoc props :interactive?) :view-box "0 0 1024 640")))))
-
-
 
 (defn <keymap-layout> [device svg layout props]
   (if layout


### PR DESCRIPTION
The keymap editor was crashing for the virtual device; this commit fixes that so it displays properly. Hopefully it will work for actual devices too!