### PR TITLE
Update old GitHub URLs to point to the Lepidopterarium organization

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,11 +38,11 @@ Released on 2017-05-12
 ## Notable changes
 
 * Instead of scanning devices only on startup, or by a manual trigger, Chrysalis now re-scans the devices whenever an USB device is plugged in, or out.
-* The menu has been redesigned, and the various pages now appear in a drop-down. ([#71](https://github.com/algernon/Chrysalis/issues/71))
-* We now have an `About` page. ([#62](https://github.com/algernon/Chrysalis/issues/62))
+* The menu has been redesigned, and the various pages now appear in a drop-down. ([#71](https://github.com/Lepidopterarium/Chrysalis/issues/71))
+* We now have an `About` page. ([#62](https://github.com/Lepidopterarium/Chrysalis/issues/62))
 * Settings are now stored and loaded when needed. This includes the window state, too.
-  
-## LED Theme Editor ([#54](https://github.com/algernon/Chrysalis/issues/54))
+
+## LED Theme Editor ([#54](https://github.com/Lepidopterarium/Chrysalis/issues/54))
 
 * New page, to edit LED themes. An unpolished, proof of concept for now.
 * Presets are saved to disk, and loaded when needed. Presets are tied to a particular product.
@@ -50,19 +50,19 @@ Released on 2017-05-12
 ## REPL
 
 * The history item is displayed even while the results are still coming in - with a spinner in place of the output.
-  
+
 ## Firmware Flasher
 
 * The name of the last `HEX` file flashed is saved on disk, per-product.
-  
-## Wire Traffic Spy ([#64](https://github.com/algernon/Chrysalis/issues/64))
+
+## Wire Traffic Spy ([#64](https://github.com/Lepidopterarium/Chrysalis/issues/64))
 
 * New page, to see what we send to the keyboard, and what we get back, without any transformations, raw as it is.
 
 ## Behind the scenes
 
 * Building from source was made considerably easier.
-* Communicating with the keyboard was made a lot more responsive, by transitioning from fixed timeouts to event-based I/O. ([#58](https://github.com/algernon/Chrysalis/issues/58), [#65](https://github.com/algernon/Chrysalis/issues/65))
+* Communicating with the keyboard was made a lot more responsive, by transitioning from fixed timeouts to event-based I/O. ([#58](https://github.com/Lepidopterarium/Chrysalis/issues/58), [#65](https://github.com/Lepidopterarium/Chrysalis/issues/65))
 * Right-click now brings up a simple context menu, primarily for the `Inspect item` functionality during development.
 * Chrysalis now sets an icon for its application (a placeholder at this time).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [Kaleidoscope][kaleidoscope] command center, a [heavy work in progress][chrysalis:project:1.0]. For the latest news, please check the [NEWS.md](NEWS.md) file, or [algernon's blog][blog:algernon:chrysalis].
 
  [kaleidoscope]: https://github.com/keyboardio/Kaleidoscope
- [chrysalis:project:1.0]: https://github.com/algernon/Chrysalis/projects/1
+ [chrysalis:project:1.0]: https://github.com/Lepidopterarium/Chrysalis/projects/1
  [blog:algernon:chrysalis]: https://asylum.madhouse-project.org/blog/tags/chrysalis/
 
 ![Chrysalis](docs/screenshots/led-theme-editor.png)

--- a/src/chrysalis/ui/about.cljs
+++ b/src/chrysalis/ui/about.cljs
@@ -31,7 +31,7 @@
            [:span "×"]]]
          [:div.modal-body
           [:div.card
-           [:a {:href "https://github.com/algernon/Chrysalis"
+           [:a {:href "https://github.com/Lepidopterarium/Chrysalis"
                 :style {:margin :auto}}
             [:img.card-img-top {:alt "Kaleidoscope Logo"
                                 :width "350"
@@ -39,7 +39,7 @@
                                 :src "images/kaleidoscope-logo-ph-small.png"}]]
            [:div.card-block
             [:h4.card-title "Chrysalis " (.getVersion app)
-             [:small " " [:a.link-button {:href (str "https://github.com/algernon/Chrysalis/releases/tag/chrysalis-"
+             [:small " " [:a.link-button {:href (str "https://github.com/Lepidopterarium/Chrysalis/releases/tag/chrysalis-"
                                                      (.getVersion app))
                                           :title "Release notes"}
                           [:i.fa.fa-id-card-o]]]]


### PR DESCRIPTION
Instead of referring to algernon/Chrysalis, refer to Lepidopterarium/Chrysalis instead, throughout the code & documentation.
